### PR TITLE
Update keygen with new ntrugen code (11-26% faster, 18% smaller RAM usage)

### DIFF
--- a/Reference_Implementation/tests/test_self.c
+++ b/Reference_Implementation/tests/test_self.c
@@ -610,9 +610,9 @@ main(void)
 	test_shake();
 	test_shake_x4();
 
-	test_multiple_sigs(8, 100, "d05fbd38bb376ebc30ed32c5752129a66b7bd443");
-	test_multiple_sigs(9, 100, "cd0c0bd8dc16ccccda4a19a7a1394d089036030d");
-	test_multiple_sigs(10, 100, "5537795eeec59376a1710fa4ec9e38d582bd0b68");
+	test_multiple_sigs(8, 100, "d859a38f775e9554eef8125ec4c7fab4f3902ac1");
+	test_multiple_sigs(9, 100, "13bab724bc2dffaa7822a9f155adb878f79c2da6");
+	test_multiple_sigs(10, 100, "f19246ade2b734f9d243f91fa8ca658262d858ff");
 
 	printf("degree      priv     pub     sig\n");
 	for (unsigned logn = 8; logn <= 10; logn ++) {

--- a/src/hawk.h
+++ b/src/hawk.h
@@ -66,7 +66,7 @@
 /*
  * Temporary buffer size for key pair generation.
  */
-#define HAWK_TMPSIZE_KEYGEN(logn)         ((26u << (logn)) + 7)
+#define HAWK_TMPSIZE_KEYGEN(logn)         ((22u << (logn)) + 7)
 
 /*
  * Temporary buffer size for signature generation.
@@ -113,9 +113,9 @@ typedef void (*hawk_rng)(void *ctx, void *dst, size_t len);
  * 1 is returned.
  *
  * The temporary buffer is provided as tmp, with size tmp_len bytes.
- * In all generality, providing at least 26*(2^logn) + 7 bytes is always
+ * In all generality, providing at least 22*(2^logn) + 7 bytes is always
  * sufficient (this is the value returned by HAWK_TMPSIZE_KEYGEN).
- * If tmp is 8-byte aligned, then 26*(2^logn) bytes are enough.
+ * If tmp is 8-byte aligned, then 22*(2^logn) bytes are enough.
  */
 int
 hawk_keygen(unsigned logn, void *priv, void *pub,

--- a/src/hawk_vrfy.c
+++ b/src/hawk_vrfy.c
@@ -1987,7 +1987,8 @@ decode_gr_vpart(unsigned logn, int16_t *d, const uint8_t *buf, size_t buf_len,
 	uint64_t acc = 0;
 	unsigned acc_len = 0;
 	size_t du;
-	__m128i xlim = _mm_set1_epi16((1 << (lim_bits - low)) - 1);
+	unsigned lhi = 1 << (lim_bits - low);
+	__m128i xlim = _mm_set1_epi16(lhi - 1);
 	__m128i xlow = _mm_cvtsi32_si128(low);
 	for (du = 0; du < n; du += 8) {
 		if (voff + 8 > buf_len) {
@@ -2102,7 +2103,7 @@ decode_gr_vpart(unsigned logn, int16_t *d, const uint8_t *buf, size_t buf_len,
 		acc &= ~((uint64_t)-1 << acc_len);
 		for (size_t v = 0; v < 8; v ++) {
 			while (acc == 0) {
-				if (acc_len > 15) {
+				if (acc_len >= lhi) {
 					return 0;
 				}
 				if (voff >= buf_len) {
@@ -2116,7 +2117,7 @@ decode_gr_vpart(unsigned logn, int16_t *d, const uint8_t *buf, size_t buf_len,
 #else
 			unsigned k = _tzcnt_u32((uint32_t)acc);
 #endif
-			if (k > 15) {
+			if (k >= lhi) {
 				return 0;
 			}
 			acc >>= k + 1;
@@ -2131,7 +2132,7 @@ decode_gr_vpart(unsigned logn, int16_t *d, const uint8_t *buf, size_t buf_len,
 	 */
 	while (du < n) {
 		while (acc == 0) {
-			if (acc_len > 15) {
+			if (acc_len >= lhi) {
 				return 0;
 			}
 			if (voff >= buf_len) {
@@ -2145,7 +2146,7 @@ decode_gr_vpart(unsigned logn, int16_t *d, const uint8_t *buf, size_t buf_len,
 #else
 		unsigned k = _tzcnt_u32((uint32_t)acc);
 #endif
-		if (k > 15) {
+		if (k >= lhi) {
 			return 0;
 		}
 		acc >>= k + 1;

--- a/src/ng_inner.h
+++ b/src/ng_inner.h
@@ -640,6 +640,12 @@ mp_Rx31(unsigned e, uint32_t p, uint32_t p0i, uint32_t R2)
 #define mp_div   Zn(mp_div)
 uint32_t mp_div(uint32_t x, uint32_t y, uint32_t p);
 
+#if NTRUGEN_AVX2
+#define mp_div_x8   Zn(mp_div_x8)
+TARGET_AVX2
+__m256i mp_div_x8(__m256i ynum, __m256i yden, __m256i yp);
+#endif // NTRUGEN_AVX2
+
 /*
  * Compute the roots for NTT; given g (primitive 2048-th root of 1 modulo p),
  * this fills gm[] and igm[] with powers of g and 1/g:
@@ -1115,10 +1121,8 @@ fxr_round(fxr x)
 static inline fxr
 fxr_div2e(fxr x, unsigned n)
 {
-	int64_t v;
-
-	v = *(int64_t *)&x.v;
-	x.v = (uint64_t)((v + (((int64_t)1 << n) >> 1)) >> n);
+	x.v += (((uint64_t)1 << n) >> 1);
+	x.v = (uint64_t)(*(int64_t *)&x.v >> n);
 	return x;
 }
 
@@ -1354,16 +1358,6 @@ void vect_div_autoadj_fft(unsigned logn,
 	fxr *restrict a, const fxr *restrict b);
 
 /*
- * Compute d = a*adj(a) + b*adj(b). Polynomials are in FFT representation.
- * Since d is auto-adjoint, only its first half is set; the second half
- * is _implicitly_ zero (this function does not access the second half of d).
- * Vectors a, b and d MUST NOT overlap.
- */
-#define vect_norm_fft   Zn(vect_norm_fft)
-void vect_norm_fft(unsigned logn, fxr *restrict d,
-	const fxr *restrict a, const fxr *restrict b);
-
-/*
  * Compute d = (2^e)/(a*adj(a) + b*adj(b)). Polynomials are in FFT
  * representation. Since d is auto-adjoint, only its first half is set; the
  * second half is _implicitly_ zero (this function does not access the
@@ -1372,6 +1366,13 @@ void vect_norm_fft(unsigned logn, fxr *restrict d,
 #define vect_invnorm_fft   Zn(vect_invnorm_fft)
 void vect_invnorm_fft(unsigned logn, fxr *restrict d,
 	const fxr *restrict a, const fxr *restrict b, unsigned e);
+
+/*
+ * Compute d = (2^e)*adj(a)/(a*adj(a)), written back into a[]. Polynomials
+ * are in FFT representation.
+ */
+#define vect_inv_mul2e_fft   Zn(vect_inv_mul2e_fft)
+void vect_inv_mul2e_fft(unsigned logn, fxr *a, unsigned e);
 
 /* ==================================================================== */
 /*
@@ -1492,27 +1493,26 @@ poly_sub_scaled_ntt(unsigned logn, uint32_t *restrict F, size_t Flen,
  * depth = 1
  * logn = logn_top - depth
  * Inputs:
- *    F, G    polynomials of degree 2^logn, plain integer representation (FGlen)
- *    FGlen   size of each coefficient of F and G (must be 1 or 2)
- *    f, g    polynomials of degree 2^logn_top, small coefficients
+ *    F       polynomial of degree 2^logn, plain integer representation (FGlen)
+ *    FGlen   size of each coefficient of F (must be 1 or 2)
+ *    f       polynomial of degree 2^logn_top, small coefficients
  *    k       polynomial of degree 2^logn (plain, 32-bit)
  *    sc      scaling logarithm (public value)
  *    tmp     temporary with room at least max(FGlen, 2^logn_top) words
  * Operation:
  *    F <- F - (2^sc)*k*ft
- *    G <- G - (2^sc)*k*gt
- * with (ft,gt) being the degree-n polynomials corresponding to (f,g)
+ * with ft being the degree-n polynomial corresponding to f
  * It is assumed that the result fits.
  *
  * WARNING: polynomial k is consumed in the process.
  *
  * This function uses 3*n words in tmp[].
  */
-#define poly_sub_kfg_scaled_depth1   Zn(poly_sub_kfg_scaled_depth1)
-void poly_sub_kfg_scaled_depth1(unsigned logn_top,
-	uint32_t *restrict F, uint32_t *restrict G, size_t FGlen,
+#define poly_sub_kf_scaled_depth1   Zn(poly_sub_kf_scaled_depth1)
+void poly_sub_kf_scaled_depth1(unsigned logn_top,
+	uint32_t *restrict F, size_t FGlen,
 	uint32_t *restrict k, uint32_t sc,
-	const int8_t *restrict f, const int8_t *restrict g,
+	const int8_t *restrict f,
 	uint32_t *restrict tmp);
 
 /*

--- a/src/ng_ntru.c
+++ b/src/ng_ntru.c
@@ -259,6 +259,13 @@ make_fg_deepest(const ntru_profile *prof,
 #define SOLVE_ERR_LIMIT    -3
 
 /*
+ * Offset in tmp[] for saving the intermediate (f,g) values. It is
+ * expressed in 32-bit words, and can use 'logn_top' to access the top-level
+ * degree.
+ */
+#define FG_SAVE_OFFSET   ((size_t)5 << logn_top)
+
+/*
  * Solve the NTRU equation at the deepest level. This computes the
  * integers F and G such that Res(f,X^n+1)*G - Res(g,X^n+1)*F = q.
  * The two integers are written into tmp[].
@@ -277,14 +284,9 @@ solve_NTRU_deepest(const ntru_profile *prof,
 	 * Obtained (f,g) are in RNS+NTT (since degree n = 1, this is
 	 * equivalent to RNS).
 	 */
-	if (!make_fg_deepest(prof, logn_top, f, g,
-		tmp, (size_t)6 << logn_top))
-	{
+	if (!make_fg_deepest(prof, logn_top, f, g, tmp, FG_SAVE_OFFSET)) {
 		return SOLVE_ERR_GCD;
 	}
-	/* obsolete
-	kg_stats_set_max_size(logn_top, logn_top, 3 * ((size_t)1 << logn_top));
-	*/
 
 	/*
 	 * Reorganize memory:
@@ -301,9 +303,6 @@ solve_NTRU_deepest(const ntru_profile *prof,
 	uint32_t *gp = fp + len;
 	uint32_t *t1 = gp + len;
 	memmove(fp, tmp, 2 * len * sizeof *tmp);
-	/* obsolete
-	kg_stats_set_max_size(logn_top, logn_top, 8 * len);
-	*/
 
 	/*
 	 * Convert back the resultants into plain integers.
@@ -321,11 +320,10 @@ solve_NTRU_deepest(const ntru_profile *prof,
 	/*
 	 * Multiply the obtained (F,G) by q to get a proper solution
 	 * f*G - g*F = q.
+	 * (Only F is multiplied since G is ultimately discarded.)
 	 */
 	if (prof->q != 1) {
-		if (zint_mul_small(Fp, len, prof->q) != 0
-			|| zint_mul_small(Gp, len, prof->q) != 0)
-		{
+		if (zint_mul_small(Fp, len, prof->q) != 0) {
 			return SOLVE_ERR_REDUCE;
 		}
 	}
@@ -350,8 +348,8 @@ solve_NTRU_deepest(const ntru_profile *prof,
 
 /*
  * Solving the NTRU equation, intermediate level.
- * Input is (F,G) from one level deeper (half-degree), in plain
- * representation, at the start of tmp[]; output is (F,G) from this
+ * Input is F from one level deeper (half-degree), in plain
+ * representation, at the start of tmp[]; output is F from this
  * level, written at the start of tmp[].
  *
  * Returned value: 0 on success, a negative error code otherwise.
@@ -365,7 +363,7 @@ solve_NTRU_intermediate(const ntru_profile *restrict prof,
 {
 	/*
 	 * MAX SIZE:
-	 *    input: 2 * hn * max_bl_small[depth + 1]
+	 *    input: hn * max_bl_small[depth + 1]
 	 */
 
 	unsigned logn = logn_top - depth;
@@ -373,9 +371,9 @@ solve_NTRU_intermediate(const ntru_profile *restrict prof,
 	size_t hn = n >> 1;
 
 	/*
-	 * slen   size for (f,g) at this level (also output (F,G))
-	 * llen   size for unreduced (F,G) at this level
-	 * dlen   size for input (F,G) from deeper level
+	 * slen   size for (f,g) at this level (also size of output F)
+	 * llen   size for unreduced F at this level
+	 * dlen   size for input F from deeper level
 	 * Note: we always have llen >= dlen (constraint enforced in profiles)
 	 */
 	size_t slen = prof->max_bl_small[depth];
@@ -384,21 +382,20 @@ solve_NTRU_intermediate(const ntru_profile *restrict prof,
 
 	/*
 	 * Fd   F from deeper level (dlen*hn)
-	 * Gd   G from deeper level (dlen*hn)
 	 * ft   f from this level (slen*n)
-	 * gt   g from this level (slen*n)
 	 */
 	uint32_t *Fd = tmp;
-	uint32_t *Gd = Fd + dlen * hn;
-	uint32_t *fgt = Gd + dlen * hn;
+	uint32_t *fgt = Fd + dlen * hn;
 
 	/*
 	 * Get (f,g) for this level (in RNS+NTT).
+	 * Computation of the resultants left saved copies of (f,g) at
+	 * the end of the tmp buffer, beyond some specific depth.
 	 */
 	if (depth < prof->min_save_fg[logn_top]) {
 		make_fg_intermediate(prof, logn_top, f, g, depth, fgt);
 	} else {
-		uint32_t *sav_fg = tmp + ((size_t)6 << logn_top);
+		uint32_t *sav_fg = tmp + FG_SAVE_OFFSET;
 		for (unsigned d = prof->min_save_fg[logn_top];
 			d <= depth; d ++)
 		{
@@ -406,40 +403,27 @@ solve_NTRU_intermediate(const ntru_profile *restrict prof,
 		}
 		memmove(fgt, sav_fg, 2 * slen * n * sizeof *fgt);
 	}
-	/* obsolete
-	kg_stats_set_max_size(logn_top, depth,
-		2 * dlen * hn + 3 * ((size_t)1 << logn_top));
-	*/
 
 	/*
 	 * Move buffers so that we have room for the unreduced (F,G) at
 	 * this level.
 	 *   Ft   F from this level (unreduced) (llen*n)
-	 *   Gt   G from this level (unreduced) (llen*n)
 	 *   ft   f from this level (slen*n)
 	 *   gt   g from this level (slen*n)
 	 *   Fd   F from deeper level (dlen*hn)
-	 *   Gd   G from deeper level (dlen*hn)
 	 */
 	uint32_t *Ft = tmp;
-	uint32_t *Gt = Ft + llen * n;
-	uint32_t *ft = Gt + llen * n;
+	uint32_t *ft = Ft + llen * n;
 	uint32_t *gt = ft + slen * n;
 	Fd = gt + slen * n;
-	Gd = Fd + dlen * hn;
-	uint32_t *t1 = Gd + dlen * hn;
+	uint32_t *t1 = Fd + dlen * hn;
 	memmove(ft, fgt, 2 * n * slen * sizeof *ft);
-	memmove(Fd, tmp, 2 * hn * dlen * sizeof *tmp);
-	/* obsolete
-	kg_stats_set_max_size(logn_top, depth,
-		2 * llen * n + 2 * slen * n + 2 * dlen * hn);
-	*/
+	memmove(Fd, tmp, hn * dlen * sizeof *tmp);
 
 	/*
-	 * Convert Fd and Gd to RNS, with output temporarily stored
-	 * in (Ft, Gt). Fd and Gd have degree hn only; we store the
-	 * values for each modulus p in the _last_ hn slots of the
-	 * n-word line for that modulus.
+	 * Convert Fd to RNS, with output temporarily stored in Ft. Fd
+	 * has degree hn only; we store the values for each modulus p in
+	 * the _last_ hn slots of the n-word line for that modulus.
 	 */
 	for (size_t u = 0; u < llen; u ++) {
 		uint32_t p = PRIMES[u].p;
@@ -447,7 +431,6 @@ solve_NTRU_intermediate(const ntru_profile *restrict prof,
 		uint32_t R2 = PRIMES[u].R2;
 		uint32_t Rx = mp_Rx31((unsigned)dlen, p, p0i, R2);
 		uint32_t *xt = Ft + u * n + hn;
-		uint32_t *yt = Gt + u * n + hn;
 #if NTRUGEN_AVX2
 		if (logn >= 4) {
 			__m256i yp = _mm256_set1_epi32(p);
@@ -458,15 +441,10 @@ solve_NTRU_intermediate(const ntru_profile *restrict prof,
 				_mm256_storeu_si256((__m256i *)(xt + v),
 					zint_mod_small_signed_x8(Fd + v, dlen,
 						hn, yp, yp0i, yR2, yRx));
-				_mm256_storeu_si256((__m256i *)(yt + v),
-					zint_mod_small_signed_x8(Gd + v, dlen,
-						hn, yp, yp0i, yR2, yRx));
 			}
 		} else {
 			for (size_t v = 0; v < hn; v ++) {
 				xt[v] = zint_mod_small_signed(Fd + v, dlen, hn,
-					p, p0i, R2, Rx);
-				yt[v] = zint_mod_small_signed(Gd + v, dlen, hn,
 					p, p0i, R2, Rx);
 			}
 		}
@@ -474,25 +452,17 @@ solve_NTRU_intermediate(const ntru_profile *restrict prof,
 		for (size_t v = 0; v < hn; v ++) {
 			xt[v] = zint_mod_small_signed(Fd + v, dlen, hn,
 				p, p0i, R2, Rx);
-			yt[v] = zint_mod_small_signed(Gd + v, dlen, hn,
-				p, p0i, R2, Rx);
 		}
 #endif // NTRUGEN_AVX2
 	}
 
 	/*
-	 * Fd and Gd are no longer needed.
+	 * Fd is no longer needed.
 	 */
 	t1 = Fd;
-	/* obsolete
-	kg_stats_set_max_size(logn_top, depth,
-		2 * llen * n + 2 * slen * n + llen);
-	kg_stats_set_max_size(logn_top, depth,
-		2 * llen * n + 2 * slen * n + 4 * n);
-	*/
 
 	/*
-	 * Compute (F,G) (unreduced) modulo sufficiently many small primes.
+	 * Compute F (unreduced) modulo sufficiently many small primes.
 	 * We also un-NTT (f,g) as we go; when slen primes have been
 	 * processed, we obtain (f,g) in RNS, and we apply the CRT to
 	 * get (f,g) in plain representation.
@@ -511,45 +481,37 @@ solve_NTRU_intermediate(const ntru_profile *restrict prof,
 		uint32_t R2 = PRIMES[u].R2;
 
 		/*
-		 * Memory layout: we keep Ft, Gt, ft and gt; we append:
+		 * Memory layout: we keep Ft, ft and gt; we append:
 		 *   gm    NTT support (n)
 		 *   igm   iNTT support (n)
-		 *   fx    temporary f mod p (NTT) (n)
 		 *   gx    temporary g mod p (NTT) (n)
 		 */
 		uint32_t *gm = t1;
 		uint32_t *igm = gm + n;
-		uint32_t *fx = igm + n;
-		uint32_t *gx = fx + n;
+		uint32_t *gx = igm + n;
 		mp_mkgmigm(logn, gm, igm, PRIMES[u].g, PRIMES[u].ig, p, p0i);
 		if (u < slen) {
-			memcpy(fx, ft + u * n, n * sizeof *fx);
 			memcpy(gx, gt + u * n, n * sizeof *gx);
 			mp_iNTT(logn, ft + u * n, igm, p, p0i);
 			mp_iNTT(logn, gt + u * n, igm, p, p0i);
 		} else {
 			uint32_t Rx = mp_Rx31((unsigned)slen, p, p0i, R2);
 			for (size_t v = 0; v < n; v ++) {
-				fx[v] = zint_mod_small_signed(ft + v, slen, n,
-					p, p0i, R2, Rx);
 				gx[v] = zint_mod_small_signed(gt + v, slen, n,
 					p, p0i, R2, Rx);
 			}
-			mp_NTT(logn, fx, gm, p, p0i);
 			mp_NTT(logn, gx, gm, p, p0i);
 		}
 
 		/*
-		 * We have (F,G) from deeper level in Ft and Gt, in
-		 * RNS. We apply the NTT modulo p.
+		 * We have F from deeper level in Ft, in RNS. We apply the
+		 * NTT modulo p.
 		 */
 		uint32_t *Fe = Ft + u * n;
-		uint32_t *Ge = Gt + u * n;
 		mp_NTT(logn - 1, Fe + hn, gm, p, p0i);
-		mp_NTT(logn - 1, Ge + hn, gm, p, p0i);
 
 		/*
-		 * Compute F and G (unreduced) modulo p.
+		 * Compute F (unreduced) modulo p.
 		 */
 #if NTRUGEN_AVX2
 		if (hn >= 4) {
@@ -557,103 +519,95 @@ solve_NTRU_intermediate(const ntru_profile *restrict prof,
 			__m256i yp0i = _mm256_set1_epi32(p0i);
 			__m256i yR2 = _mm256_set1_epi32(R2);
 			for (size_t v = 0; v < hn; v += 4) {
-				__m256i yfa = _mm256_loadu_si256(
-					(__m256i *)(fx + (v << 1)));
 				__m256i yga = _mm256_loadu_si256(
 					(__m256i *)(gx + (v << 1)));
-				__m256i yfb = _mm256_srli_epi64(yfa, 32);
 				__m256i ygb = _mm256_srli_epi64(yga, 32);
 				__m128i xFe = _mm_loadu_si128(
 					(__m128i *)(Fe + v + hn));
-				__m128i xGe = _mm_loadu_si128(
-					(__m128i *)(Ge + v + hn));
 				__m256i yFp = _mm256_permute4x64_epi64(
 					_mm256_castsi128_si256(xFe), 0x50);
-				__m256i yGp = _mm256_permute4x64_epi64(
-					_mm256_castsi128_si256(xGe), 0x50);
 				yFp = _mm256_shuffle_epi32(yFp, 0x30);
-				yGp = _mm256_shuffle_epi32(yGp, 0x30);
 				yFp = mp_montymul_x4(yFp, yR2, yp, yp0i);
-				yGp = mp_montymul_x4(yGp, yR2, yp, yp0i);
 				__m256i yFe0 = mp_montymul_x4(
 					ygb, yFp, yp, yp0i);
 				__m256i yFe1 = mp_montymul_x4(
 					yga, yFp, yp, yp0i);
-				__m256i yGe0 = mp_montymul_x4(
-					yfb, yGp, yp, yp0i);
-				__m256i yGe1 = mp_montymul_x4(
-					yfa, yGp, yp, yp0i);
 				_mm256_storeu_si256((__m256i *)(Fe + (v << 1)),
 					_mm256_or_si256(yFe0,
 						_mm256_slli_epi64(yFe1, 32)));
-				_mm256_storeu_si256((__m256i *)(Ge + (v << 1)),
-					_mm256_or_si256(yGe0,
-						_mm256_slli_epi64(yGe1, 32)));
 			}
 		} else {
 			for (size_t v = 0; v < hn; v ++) {
-				uint32_t fa = fx[(v << 1) + 0];
-				uint32_t fb = fx[(v << 1) + 1];
 				uint32_t ga = gx[(v << 1) + 0];
 				uint32_t gb = gx[(v << 1) + 1];
 				uint32_t mFp = mp_montymul(
 					Fe[v + hn], R2, p, p0i);
-				uint32_t mGp = mp_montymul(
-					Ge[v + hn], R2, p, p0i);
 				Fe[(v << 1) + 0] = mp_montymul(gb, mFp, p, p0i);
 				Fe[(v << 1) + 1] = mp_montymul(ga, mFp, p, p0i);
-				Ge[(v << 1) + 0] = mp_montymul(fb, mGp, p, p0i);
-				Ge[(v << 1) + 1] = mp_montymul(fa, mGp, p, p0i);
 			}
 		}
 #else // NTRUGEN_AVX2
 		for (size_t v = 0; v < hn; v ++) {
-			uint32_t fa = fx[(v << 1) + 0];
-			uint32_t fb = fx[(v << 1) + 1];
 			uint32_t ga = gx[(v << 1) + 0];
 			uint32_t gb = gx[(v << 1) + 1];
 			uint32_t mFp = mp_montymul(Fe[v + hn], R2, p, p0i);
-			uint32_t mGp = mp_montymul(Ge[v + hn], R2, p, p0i);
 			Fe[(v << 1) + 0] = mp_montymul(gb, mFp, p, p0i);
 			Fe[(v << 1) + 1] = mp_montymul(ga, mFp, p, p0i);
-			Ge[(v << 1) + 0] = mp_montymul(fb, mGp, p, p0i);
-			Ge[(v << 1) + 1] = mp_montymul(fa, mGp, p, p0i);
 		}
 #endif // NTRUGEN_AVX2
 
 		/*
-		 * We want the new (F,G) in RNS only (no NTT).
+		 * We want the new F in RNS only (no NTT).
 		 */
 		mp_iNTT(logn, Fe, igm, p, p0i);
-		mp_iNTT(logn, Ge, igm, p, p0i);
 	}
 
 	/*
-	 * Edge case: if slen == llen, then we have not rebuilt (f,g)
-	 * into plain representation yet, so we do it now.
+	 * We no longer need g.
+	 */
+	t1 = gt;
+
+	/*
+	 * Edge case: if slen == llen, then we have not rebuilt f
+	 * into plain representation yet.
 	 */
 	if (slen == llen) {
-		zint_rebuild_CRT(ft, slen, n, 2, 1, t1);
+		zint_rebuild_CRT(ft, slen, n, 1, 1, t1);
 	}
 
 	/*
-	 * We now have the unreduced (F,G) in RNS. We rebuild their
-	 * plain representation.
+	 * We now have the unreduced F in RNS. We rebuild its plain
+	 * representation.
 	 */
-	zint_rebuild_CRT(Ft, llen, n, 2, 1, t1);
+	zint_rebuild_CRT(Ft, llen, n, 1, 1, t1);
 
 	/*
-	 * We now reduce these (F,G) with Babai's nearest plane
-	 * algorithm. The reduction conceptually goes as follows:
+	 * We now reduce this F with Babai's round-off algorithm. The
+	 * reduction conceptually goes as follows:
 	 *   k <- round((F*adj(f) + G*adj(g))/(f*adj(f) + g*adj(g)))
 	 *   (F, G) <- (F - k*f, G - k*g)
-	 * We use fixed-point approximations of (f,g) and (F, G) to get
-	 * a value k as a small polynomial with scaling; we then apply
-	 * k on the full-width polynomial. Each iteration "shaves" a
-	 * a few bits off F and G.
+	 * We only have F; however, G is such that:
+	 *   f*G - g*F = q
+	 * hence:
+	 *   G = (q + g*F)/f
+	 * which we can move into the expression of k, and the expression
+	 * simplifies into:
+	 *   k = round(F/f + q*adj(g)/(f*(f*adj(f) + g*adj(g))))
+	 * The second part only depends on f and g; moreover, it is
+	 * heuristically negligible, i.e. we can compute an approximate
+	 * value of k as:
+	 *   k = round(F/f)
+	 * which is a lot simpler. In practice the approximation is good
+	 * enough for our purposes; a few coefficients are offset by +/-1
+	 * but that does not prevent reduction from succeeding most of the
+	 * time.
 	 *
-	 * We apply the process sufficiently many times to reduce (F, G)
-	 * to the size of (f, g) with a reasonable probability of success.
+	 * We use fixed-point approximations of f and F to get a value k as
+	 * a small polynomial with scaling; we then apply k on the
+	 * full-width polynomial. Each iteration "shaves" a few bits off F.
+	 *
+	 * We apply the process sufficiently many times to reduce F
+	 * to the size of f with a reasonable probability of success.
 	 * Since we want full constant-time processing, the number of
 	 * iterations and the accessed slots work on some assumptions on
 	 * the sizes of values (sizes have been measured over many samples,
@@ -662,37 +616,24 @@ solve_NTRU_intermediate(const ntru_profile *restrict prof,
 
 	/*
 	 * If depth is at least 2, and we will use the NTT to subtract
-	 * k*(f,g) from (F,G), then we will need to convert (f,g) to NTT over
-	 * slen+1 words, which requires an extra word to ft and gt.
+	 * k*f from F, then we will need to convert f to NTT over
+	 * slen+1 words, which requires an extra word to ft.
 	 */
 	int use_sub_ntt = (depth > 1 && logn >= MIN_LOGN_FGNTT);
 	if (use_sub_ntt) {
-		memmove(gt + n, gt, n * slen * sizeof *gt);
-		gt += n;
-		t1 += 2 * n;
+		t1 += n;
 	}
 
 	/*
 	 * New layout:
 	 *   Ft    F from this level (unreduced) (llen*n)
-	 *   Gt    G from this level (unreduced) (llen*n)
 	 *   ft    f from this level (slen*n) (+n if use_sub_ntt)
-	 *   gt    g from this level (slen*n) (+n if use_sub_ntt)
 	 *   rt3   (n fxr = 2*n)
-	 *   rt4   (n fxr = 2*n)
-	 *   rt1   (hn fxr = n)
 	 */
-
 	fxr *rt3 = (fxr *)t1;
-	fxr *rt4 = rt3 + n;
-	fxr *rt1 = rt4 + n;
-	/* obsolete
-	kg_stats_set_max_size(logn_top, depth,
-		2 * llen * n + 2 * slen * n + 5 * n);
-	*/
 
 	/*
-	 * We consider only the top rlen words of (f,g).
+	 * We consider only the top rlen words of f.
 	 */
 	size_t rlen = prof->word_win[depth];
 	if (rlen > slen) {
@@ -700,21 +641,19 @@ solve_NTRU_intermediate(const ntru_profile *restrict prof,
 	}
 	size_t blen = slen - rlen;
 	uint32_t *ftb = ft + blen * n;
-	uint32_t *gtb = gt + blen * n;
 	uint32_t scale_fg = 31 * (uint32_t)blen;
 	uint32_t scale_FG = 31 * (uint32_t)llen;
 
 	/*
-	 * Convert f and g into fixed-point approximations, in rt3 and rt4,
-	 * respectively. They are scaled down by 2^(scale_fg + scale_x).
-	 * scale_fg is public (it depends only on the recursion depth), but
-	 * scale_x comes from a measurement on the actual values of (f,g) and
-	 * is thus secret.
+	 * Convert f into fixed-point approximations, into rt3. It is scaled
+	 * down by 2^(scale_fg + scale_x). scale_fg is public (it depends
+	 * only on the recursion depth), but scale_x comes from a measurement
+	 * on the actual coefficient values of f and is thus secret.
 	 *
 	 * The value scale_x is adjusted so that the largest coefficient is
 	 * close to, but lower than, some limit t (in absolute value). The
-	 * limit t is chosen so that f*adj(f) + g*adj(g) does not overflow,
-	 * i.e. all coefficients must remain below 2^31.
+	 * limit t is chosen so that f*adj(f) does not overflow, i.e. all
+	 * coefficients must remain below 2^31.
 	 *
 	 * Let n be the degree; we know that n <= 2^10. The squared norm
 	 * of a polynomial is the sum of the squared norms of the
@@ -732,96 +671,41 @@ solve_NTRU_intermediate(const ntru_profile *restrict prof,
 	 * coefficient with its conjugate; thus, the coefficients of
 	 * f*adj(f), in FFT representation, are at most n^2*t^2.
 	 *
-	 * Since we want the coefficients of f*adj(f)+g*adj(g) not to exceed
-	 * 2^31, we need n^2*t^2 <= 2^30, i.e. n*t <= 2^15. We can adjust t
+	 * Since we want the coefficients of f*adj(f) not to exceed
+	 * 2^31, we need n^2*t^2 <= 2^31, i.e. n*t <= 2^15.5. We can adjust t
 	 * accordingly (called scale_t in the code below). We also need to
-	 * take care that t must not exceed scale_x. Approximation of f and
-	 * g are extracted with scale scale_fg + scale_x - scale_t, and
-	 * later fixed by dividing them by 2^scale_t.
+	 * take care that t must not exceed scale_x. Approximation of f
+	 * is extracted with scale scale_fg + scale_x - scale_t, and
+	 * later fixed by dividing it by 2^scale_t.
 	 */
-	uint32_t scale_xf = poly_max_bitlength(logn, ftb, rlen);
-	uint32_t scale_xg = poly_max_bitlength(logn, gtb, rlen);
-	uint32_t scale_x = scale_xf;
-	scale_x ^= (scale_xf ^ scale_xg) & tbmask(scale_xf - scale_xg);
+	uint32_t scale_x = poly_max_bitlength(logn, ftb, rlen);
 	uint32_t scale_t = 15 - logn;
 	scale_t ^= (scale_t ^ scale_x) & tbmask(scale_x - scale_t);
 	uint32_t scdiff = scale_x - scale_t;
 
 	poly_big_to_fixed(logn, rt3, ftb, rlen, scdiff);
-	poly_big_to_fixed(logn, rt4, gtb, rlen, scdiff);
 
 	/*
-	 * Compute adj(f)/(f*adj(f) + g*adj(g)) into rt3 (FFT).
-	 * Compute adj(g)/(f*adj(f) + g*adj(g)) into rt4 (FFT).
+	 * Compute adj(f)/(f*adj(f)) into rt3 (FFT, with scaling).
 	 */
 	vect_FFT(logn, rt3);
-	vect_FFT(logn, rt4);
-	vect_norm_fft(logn, rt1, rt3, rt4);
-	vect_mul2e(logn, rt3, scale_t);
-	vect_mul2e(logn, rt4, scale_t);
-	for (size_t u = 0; u < hn; u ++) {
-#if NTRUGEN_AVX2
-		fxr ni3 = fxr_neg(rt3[u + hn]);
-		fxr ni4 = fxr_neg(rt4[u + hn]);
-		fxr_div_x4_1(&rt3[u], &ni3, &rt4[u], &ni4, rt1[u]);
-		rt3[u + hn] = ni3;
-		rt4[u + hn] = ni4;
-#else // NTRUGEN_AVX2
-		rt3[u] = fxr_div(rt3[u], rt1[u]);
-		rt3[u + hn] = fxr_div(fxr_neg(rt3[u + hn]), rt1[u]);
-		rt4[u] = fxr_div(rt4[u], rt1[u]);
-		rt4[u + hn] = fxr_div(fxr_neg(rt4[u + hn]), rt1[u]);
-#endif // NTRUGEN_AVX2
-	}
+	vect_inv_mul2e_fft(logn, rt3, scale_t);
 
 	/*
 	 * New layout:
 	 *   Ft    F from this level (unreduced) (llen*n)
-	 *   Gt    G from this level (unreduced) (llen*n)
 	 *   ft    f from this level (slen*n) (+n if use_sub_ntt)
-	 *   gt    g from this level (slen*n) (+n if use_sub_ntt)
 	 *   rt3   (n fxr = 2*n)
-	 *   rt4   (n fxr = 2*n)
 	 *   rt1   (n fxr = 2*n)     |   k    (n)
-	 *   rt2   (n fxr = 2*n)     |   t2   (3*n)
-	 * Exception: at depth == 1, we omit ft and gt:
-	 *   Ft    F from this level (unreduced) (llen*n)
-	 *   Gt    G from this level (unreduced) (llen*n)
-	 *   rt3   (n fxr = 2*n)
-	 *   rt4   (n fxr = 2*n)
-	 *   rt1   (n fxr = 2*n)     |   k    (n)
-	 *   rt2   (n fxr = 2*n)     |   t2   (3*n)
+	 *                           |   t2   (3*n)
 	 */
-	if (depth == 1) {
-		t1 = ft;
-		fxr *nrt3 = (fxr *)t1;
-		memmove(nrt3, rt3, 2 * n * sizeof *rt3);
-		rt3 = nrt3;
-		rt4 = rt3 + n;
-		rt1 = rt4 + n;
-	}
+	fxr *rt1 = rt3 + n;
 	int32_t *k = (int32_t *)rt1;
 	uint32_t *t2 = (uint32_t *)(k + n);
-	fxr *rt2 = (fxr *)t2;
-	if (rt2 < (rt1 + n)) {
-		rt2 = rt1 + n;
-	}
-	/* obsolete
-	if (depth == 1) {
-		kg_stats_set_max_size(logn_top, depth,
-			2 * llen * n + 8 * n);
-	} else {
-		kg_stats_set_max_size(logn_top, depth,
-			2 * llen * n + 2 * slen * n + 8 * n);
-		kg_stats_set_max_size(logn_top, depth,
-			2 * llen * n + 2 * slen * n + 4 * n + n
-			+ 2 * n + (slen + 1) * n + n);
-	}
-	*/
 
 	/*
 	 * If we are going to use poly_sub_scaled_ntt(), then we convert
-	 * f and g to the NTT representation. Since poly_sub_scaled_ntt()
+	 * f to the NTT representation. Since poly_sub_scaled_ntt()
 	 * itself will use more than n*(slen+2) words in t2[], we can do
 	 * the same here.
 	 */
@@ -843,73 +727,50 @@ solve_NTRU_intermediate(const ntru_profile *restrict prof,
 		}
 		tn = gm + n;
 		memmove(ft, tn, (slen + 1) * n * sizeof *tn);
-		for (size_t u = 0; u <= slen; u ++) {
-			uint32_t p = PRIMES[u].p;
-			uint32_t p0i = PRIMES[u].p0i;
-			uint32_t R2 = PRIMES[u].R2;
-			uint32_t Rx = mp_Rx31((unsigned)slen, p, p0i, R2);
-			mp_mkgm(logn, gm, PRIMES[u].g, p, p0i);
-			for (size_t v = 0; v < n; v ++) {
-				tn[v] = zint_mod_small_signed(
-					gt + v, slen, n, p, p0i, R2, Rx);
-			}
-			mp_NTT(logn, tn, gm, p, p0i);
-			tn += n;
-		}
-		tn = gm + n;
-		memmove(gt, tn, (slen + 1) * n * sizeof *tn);
 	}
 
 	/*
-	 * Reduce F and G repeatedly.
+	 * Reduce F repeatedly.
 	 */
 	size_t FGlen = llen;
 	for (;;) {
 		/*
-		 * Convert the current F and G into fixed-point. We want
+		 * Convert the current F into fixed-point. We want
 		 * to apply scaling scale_FG + scale_x.
 		 */
 		uint32_t tlen, toff;
 		DIVREM31(tlen, toff, scale_FG);
 		poly_big_to_fixed(logn, rt1,
 			Ft + tlen * n, FGlen - tlen, scale_x + toff);
-		poly_big_to_fixed(logn, rt2,
-			Gt + tlen * n, FGlen - tlen, scale_x + toff);
 
 		/*
-		 * rt2 <- (F*adj(f) + G*adj(g)) / (f*adj(f) + g*adj(g))
+		 * rt1 <- (F*adj(f)) / (f*adj(f))
 		 */
 		vect_FFT(logn, rt1);
-		vect_FFT(logn, rt2);
 		vect_mul_fft(logn, rt1, rt3);
-		vect_mul_fft(logn, rt2, rt4);
-		vect_add(logn, rt2, rt1);
-		vect_iFFT(logn, rt2);
+		vect_iFFT(logn, rt1);
 
 		/*
-		 * k <- round(rt2)
+		 * k <- round(rt1)
 		 */
 		for (size_t u = 0; u < n; u ++) {
-			k[u] = fxr_round(rt2[u]);
+			k[u] = fxr_round(rt1[u]);
 		}
 
 		/*
-		 * (f,g) are scaled by scale_fg + scale_x
-		 * (F,G) are scaled by scale_FG + scale_x
+		 * f is scaled by scale_fg + scale_x
+		 * F is scaled by scale_FG + scale_x
 		 * Thus, k is scaled by scale_FG - scale_fg, which is public.
 		 */
 		uint32_t scale_k = scale_FG - scale_fg;
 		if (depth == 1) {
-			poly_sub_kfg_scaled_depth1(logn_top, Ft, Gt, FGlen,
-				(uint32_t *)k, scale_k, f, g, t2);
+			poly_sub_kf_scaled_depth1(logn_top, Ft, FGlen,
+				(uint32_t *)k, scale_k, f, t2);
 		} else if (use_sub_ntt) {
 			poly_sub_scaled_ntt(logn, Ft, FGlen, ft, slen,
 				k, scale_k, t2);
-			poly_sub_scaled_ntt(logn, Gt, FGlen, gt, slen,
-				k, scale_k, t2);
 		} else {
 			poly_sub_scaled(logn, Ft, FGlen, ft, slen, k, scale_k);
-			poly_sub_scaled(logn, Gt, FGlen, gt, slen, k, scale_k);
 		}
 
 		/*
@@ -927,135 +788,39 @@ solve_NTRU_intermediate(const ntru_profile *restrict prof,
 		while (FGlen > slen
 			&& 31 * (FGlen - slen) > scale_FG - scale_fg + 30)
 		{
+			/*
+			 * We decrement FGlen; when we do so, we check that
+			 * it does not damage any of the value, i.e. that the
+			 * removed words are redundant with the the remaining
+			 * words. If a non-redundant word is removed then
+			 * the reduction failed. A contrario, as long as such
+			 * removal works, then we know that the reduction
+			 * keeps working and the computation so far is
+			 * correct.
+			 */
 			FGlen --;
+			uint32_t *xp = &Ft[(FGlen - 1) << logn];
+			for (size_t u = 0; u < n; u ++) {
+				uint32_t sw = -(xp[u] >> 30) >> 1;
+				if (xp[u + n] != sw) {
+					return SOLVE_ERR_REDUCE;
+				}
+			}
 		}
 	}
 
 	/*
-	 * Output F is already in the right place; G is in Gt, and must be
-	 * moved back a bit.
+	 * Output F is already in the right place.
 	 */
-	memmove(tmp + slen * n, Gt, slen * n * sizeof *tmp);
-	Gt = tmp + slen * n;
-
-	/*
-	 * Reduction is done. We test the current solution modulo a single
-	 * prime.
-	 * Exception: we cannot do that if depth == 1, since in that case
-	 * we did not keep (ft,gt). Reduction errors rarely occur at this
-	 * stage, so we can omit that test (depth-0 test will cover it).
-	 *
-	 * If use_sub_ntt != 0, then ft and gt are already in NTT
-	 * representation.
-	 */
-	if (depth == 1) {
-		return SOLVE_OK;
-	}
-
-	t2 = t1 + n;
-	uint32_t *t3 = t2 + n;
-	uint32_t *t4 = t3 + n;
-	uint32_t p = PRIMES[0].p;
-	uint32_t p0i = PRIMES[0].p0i;
-	uint32_t R2 = PRIMES[0].R2;
-	uint32_t Rx = mp_Rx31(slen, p, p0i, R2);
-	mp_mkgm(logn, t4, PRIMES[0].g, p, p0i);
-	if (use_sub_ntt) {
-		t1 = ft;
-		for (size_t u = 0; u < n; u ++) {
-			t2[u] = zint_mod_small_signed(
-				Gt + u, slen, n, p, p0i, R2, Rx);
-		}
-		mp_NTT(logn, t2, t4, p, p0i);
-	} else {
-		for (size_t u = 0; u < n; u ++) {
-			t1[u] = zint_mod_small_signed(
-				ft + u, slen, n, p, p0i, R2, Rx);
-			t2[u] = zint_mod_small_signed(
-				Gt + u, slen, n, p, p0i, R2, Rx);
-		}
-		mp_NTT(logn, t1, t4, p, p0i);
-		mp_NTT(logn, t2, t4, p, p0i);
-	}
-#if NTRUGEN_AVX2
-	if (n >= 8) {
-		__m256i yp = _mm256_set1_epi32(p);
-		__m256i yp0i = _mm256_set1_epi32(p0i);
-		for (size_t u = 0; u < n; u += 8) {
-			__m256i y1 = _mm256_loadu_si256((__m256i *)(t1 + u));
-			__m256i y2 = _mm256_loadu_si256((__m256i *)(t2 + u));
-			__m256i y3 = mp_montymul_x8(y1, y2, yp, yp0i);
-			_mm256_storeu_si256((__m256i *)(t3 + u), y3);
-		}
-	} else {
-		for (size_t u = 0; u < n; u ++) {
-			t3[u] = mp_montymul(t1[u], t2[u], p, p0i);
-		}
-	}
-#else // NTRUGEN_AVX2
-	for (size_t u = 0; u < n; u ++) {
-		t3[u] = mp_montymul(t1[u], t2[u], p, p0i);
-	}
-#endif // NTRUGEN_AVX2
-	if (use_sub_ntt) {
-		t1 = gt;
-		for (size_t u = 0; u < n; u ++) {
-			t2[u] = zint_mod_small_signed(
-				Ft + u, slen, n, p, p0i, R2, Rx);
-		}
-		mp_NTT(logn, t2, t4, p, p0i);
-	} else {
-		for (size_t u = 0; u < n; u ++) {
-			t1[u] = zint_mod_small_signed(
-				gt + u, slen, n, p, p0i, R2, Rx);
-			t2[u] = zint_mod_small_signed(
-				Ft + u, slen, n, p, p0i, R2, Rx);
-		}
-		mp_NTT(logn, t1, t4, p, p0i);
-		mp_NTT(logn, t2, t4, p, p0i);
-	}
-	uint32_t rv = mp_montymul(prof->q, 1, p, p0i);
-#if NTRUGEN_AVX2
-	if (n >= 8) {
-		__m256i yp = _mm256_set1_epi32(p);
-		__m256i yp0i = _mm256_set1_epi32(p0i);
-		__m256i yrv = _mm256_set1_epi32(rv);
-		for (size_t u = 0; u < n; u += 8) {
-			__m256i y1 = _mm256_loadu_si256((__m256i *)(t1 + u));
-			__m256i y2 = _mm256_loadu_si256((__m256i *)(t2 + u));
-			__m256i y3 = _mm256_loadu_si256((__m256i *)(t3 + u));
-			__m256i yx = mp_sub_x8(y3,
-				mp_montymul_x8(y1, y2, yp, yp0i), yp);
-			if ((uint32_t)_mm256_movemask_epi8(
-				_mm256_cmpeq_epi32(yx, yrv)) != 0xFFFFFFFF)
-			{
-				return SOLVE_ERR_REDUCE;
-			}
-		}
-	} else {
-		for (size_t u = 0; u < n; u ++) {
-			uint32_t x = mp_montymul(t1[u], t2[u], p, p0i);
-			if (mp_sub(t3[u], x, p) != rv) {
-				return SOLVE_ERR_REDUCE;
-			}
-		}
-	}
-#else // NTRUGEN_AVX2
-	for (size_t u = 0; u < n; u ++) {
-		uint32_t x = mp_montymul(t1[u], t2[u], p, p0i);
-		if (mp_sub(t3[u], x, p) != rv) {
-			return SOLVE_ERR_REDUCE;
-		}
-	}
-#endif // NTRUGEN_AVX2
-
 	return SOLVE_OK;
 }
 
 /*
  * Solving the NTRU equation, top recursion level. This is a specialized
  * variant for solve_NTRU_intermediate() with depth == 0, for lower RAM
- * usage and faster operation.
+ * usage and faster operation; it also ensures better precision for the
+ * reduction. This function returns both F and G, in that order, at the
+ * start of tmp[].
  *
  * Returned value: 0 on success, a negative error code otherwise.
  */
@@ -1078,333 +843,443 @@ solve_NTRU_depth0(const ntru_profile *restrict prof,
 	uint32_t R2 = PRIMES[0].R2;
 
 	/*
-	 * Buffer layout:
-	 *   Fd   F from upper level (hn)
-	 *   Gd   G from upper level (hn)
-	 *   ft   f (n)
-	 *   gt   g (n)
-	 *   gm   helper for NTT
+	 * On input, Fd from upper level (hn words) is at the start of
+	 * tmp[].
 	 */
-	uint32_t *Fd = tmp;
-	uint32_t *Gd = Fd + hn;
-	uint32_t *ft = Gd + hn;
-	uint32_t *gt = ft + n;
-	uint32_t *gm = gt + n;
-	/* obsolete
-	kg_stats_set_max_size(logn, 0, 2 * hn + 3 * n);
-	*/
+	uint32_t *t1 = tmp;
+	uint32_t *t2 = t1 + n;
+	uint32_t *t3 = t2 + n;
+	uint32_t *t4 = t3 + n;
+	uint32_t *t5 = t4 + n;
 
 	/*
-	 * Load f and g, and convert to RNS+NTT.
+	 * Convert Fd to RNS+NTT, into t3.
 	 */
+	uint32_t *gm = t4;
 	mp_mkgm(logn, gm, PRIMES[0].g, p, p0i);
-	poly_mp_set_small(logn, ft, f, p);
-	poly_mp_set_small(logn, gt, g, p);
-	mp_NTT(logn, ft, gm, p, p0i);
-	mp_NTT(logn, gt, gm, p, p0i);
+	poly_mp_set(logn - 1, t1, p);
+	mp_NTT(logn - 1, t1, gm, p, p0i);
+	memcpy(t3, t1, hn * sizeof *t1);
 
 	/*
-	 * Convert Fd and Gd to RNS+NTT.
+	 * Compute F (unreduced, RNS+NTT) into t1.
 	 */
-	poly_mp_set(logn - 1, Fd, p);
-	poly_mp_set(logn - 1, Gd, p);
-	mp_NTT(logn - 1, Fd, gm, p, p0i);
-	mp_NTT(logn - 1, Gd, gm, p, p0i);
-
-	/*
-	 * Build the unreduced (F,G) into ft and gt.
-	 */
+	poly_mp_set_small(logn, t2, g, p);
+	mp_NTT(logn, t2, gm, p, p0i);
 #if NTRUGEN_AVX2
 	if (hn >= 4) {
 		__m256i yp = _mm256_set1_epi32(p);
 		__m256i yp0i = _mm256_set1_epi32(p0i);
 		__m256i yR2 = _mm256_set1_epi32(R2);
-		for (size_t v = 0; v < hn; v += 4) {
-			__m256i yfa = _mm256_loadu_si256(
-				(__m256i *)(ft + (v << 1)));
+		for (size_t u = 0; u < hn; u += 4) {
 			__m256i yga = _mm256_loadu_si256(
-				(__m256i *)(gt + (v << 1)));
-			__m256i yfb = _mm256_srli_epi64(yfa, 32);
+				(__m256i *)(t2 + (u << 1)));
 			__m256i ygb = _mm256_srli_epi64(yga, 32);
-			__m128i xFd = _mm_loadu_si128((__m128i *)(Fd + v));
-			__m128i xGd = _mm_loadu_si128((__m128i *)(Gd + v));
+			__m128i xFd = _mm_loadu_si128((__m128i *)(t3 + u));
 			__m256i yFd = _mm256_permute4x64_epi64(
 				_mm256_castsi128_si256(xFd), 0x50);
-			__m256i yGd = _mm256_permute4x64_epi64(
-				_mm256_castsi128_si256(xGd), 0x50);
 			yFd = _mm256_shuffle_epi32(yFd, 0x30);
-			yGd = _mm256_shuffle_epi32(yGd, 0x30);
 			yFd = mp_montymul_x4(yFd, yR2, yp, yp0i);
-			yGd = mp_montymul_x4(yGd, yR2, yp, yp0i);
 			__m256i yFe0 = mp_montymul_x4(ygb, yFd, yp, yp0i);
 			__m256i yFe1 = mp_montymul_x4(yga, yFd, yp, yp0i);
-			__m256i yGe0 = mp_montymul_x4(yfb, yGd, yp, yp0i);
-			__m256i yGe1 = mp_montymul_x4(yfa, yGd, yp, yp0i);
-			_mm256_storeu_si256((__m256i *)(ft + (v << 1)),
+			_mm256_storeu_si256((__m256i *)(t1 + (u << 1)),
 				_mm256_or_si256(yFe0,
 					_mm256_slli_epi64(yFe1, 32)));
-			_mm256_storeu_si256((__m256i *)(gt + (v << 1)),
-				_mm256_or_si256(yGe0,
-					_mm256_slli_epi64(yGe1, 32)));
 		}
 	} else {
-		for (size_t v = 0; v < hn; v ++) {
-			uint32_t fa = ft[(v << 1) + 0];
-			uint32_t fb = ft[(v << 1) + 1];
-			uint32_t ga = gt[(v << 1) + 0];
-			uint32_t gb = gt[(v << 1) + 1];
-			uint32_t mFd = mp_montymul(Fd[v], R2, p, p0i);
-			uint32_t mGd = mp_montymul(Gd[v], R2, p, p0i);
-			ft[(v << 1) + 0] = mp_montymul(gb, mFd, p, p0i);
-			ft[(v << 1) + 1] = mp_montymul(ga, mFd, p, p0i);
-			gt[(v << 1) + 0] = mp_montymul(fb, mGd, p, p0i);
-			gt[(v << 1) + 1] = mp_montymul(fa, mGd, p, p0i);
+		for (size_t u = 0; u < hn; u ++) {
+			uint32_t ga = t2[(u << 1) + 0];
+			uint32_t gb = t2[(u << 1) + 1];
+			uint32_t mF = mp_montymul(t3[u], R2, p, p0i);
+			t1[(u << 1) + 0] = mp_montymul(gb, mF, p, p0i);
+			t1[(u << 1) + 1] = mp_montymul(ga, mF, p, p0i);
 		}
 	}
 #else // NTRUGEN_AVX2
 	for (size_t u = 0; u < hn; u ++) {
-		uint32_t fa = ft[(u << 1) + 0];
-		uint32_t fb = ft[(u << 1) + 1];
-		uint32_t ga = gt[(u << 1) + 0];
-		uint32_t gb = gt[(u << 1) + 1];
-		uint32_t mFd = mp_montymul(Fd[u], R2, p, p0i);
-		uint32_t mGd = mp_montymul(Gd[u], R2, p, p0i);
-		ft[(u << 1) + 0] = mp_montymul(gb, mFd, p, p0i);
-		ft[(u << 1) + 1] = mp_montymul(ga, mFd, p, p0i);
-		gt[(u << 1) + 0] = mp_montymul(fb, mGd, p, p0i);
-		gt[(u << 1) + 1] = mp_montymul(fa, mGd, p, p0i);
+		uint32_t ga = t2[(u << 1) + 0];
+		uint32_t gb = t2[(u << 1) + 1];
+		uint32_t mF = mp_montymul(t3[u], R2, p, p0i);
+		t1[(u << 1) + 0] = mp_montymul(gb, mF, p, p0i);
+		t1[(u << 1) + 1] = mp_montymul(ga, mF, p, p0i);
 	}
 #endif // NTRUGEN_AVX2
 
 	/*
-	 * Reorganize buffers:
-	 *   Fp   unreduced F (RNS+NTT) (n)
-	 *   Gp   unreduced G (RNS+NTT) (n)
-	 *   t1   free (n)
-	 *   t2   NTT support (gm) (n)
-	 *   t3   free (n)
-	 *   t4   free (n)
-	 */
-	uint32_t *Fp = tmp;
-	uint32_t *Gp = Fp + n;
-	uint32_t *t1 = Gp + n;
-	uint32_t *t2 = t1 + n;  /* alias on gm */
-	uint32_t *t3 = t2 + n;
-	uint32_t *t4 = t3 + n;
-	memmove(Fp, ft, 2 * n * sizeof *ft);
-	/* obsolete
-	kg_stats_set_max_size(logn, 0, 6 * n);
-	*/
-
-	/*
-	 * Working modulo p (using the NTT), we compute:
-	 *    t1 <- F*adj(f) + G*adj(g)
-	 *    t2 <- f*adj(f) + g*adj(g)
+	 * Layout:
+	 *   t1   F (unreduced, RNS+NTT)
+	 *   t2   g (RNS+NTT)
+	 *   t3   free
+	 *   t4   gm (NTT support)
+	 *   t5   free
 	 */
 
 	/*
-	 * t4 <- f (RNS+NTT)
+	 * Convert f to RNS+NTT. Since we are going to divide by f modulo p,
+	 * we also need to check that f is invertible modulo p (which should
+	 * almost always be the case in practice).
+	 *   t3 <- f (RNS+NTT)
 	 */
-	poly_mp_set_small(logn, t4, f, p);
-	mp_NTT(logn, t4, gm, p, p0i);
-
-	/*
-	 * t1 <- F*adj(f) (RNS+NTT)
-	 * t3 <- f*adj(f) (RNS+NTT)
-	 */
+	poly_mp_set_small(logn, t3, f, p);
+	mp_NTT(logn, t3, gm, p, p0i);
 	for (size_t u = 0; u < n; u ++) {
-		uint32_t w = mp_montymul(t4[(n - 1) - u], R2, p, p0i);
-		t1[u] = mp_montymul(w, Fp[u], p, p0i);
-		t3[u] = mp_montymul(w, t4[u], p, p0i);
-	}
-
-	/*
-	 * t4 <- g (RNS+NTT)
-	 */
-	poly_mp_set_small(logn, t4, g, p);
-	mp_NTT(logn, t4, gm, p, p0i);
-
-	/*
-	 * t1 <- t1 + G*adj(g)
-	 * t3 <- t3 + g*adj(g)
-	 */
-	for (size_t u = 0; u < n; u ++) {
-		uint32_t w = mp_montymul(t4[(n - 1) - u], R2, p, p0i);
-		t1[u] = mp_add(t1[u], mp_montymul(w, Gp[u], p, p0i), p);
-		t3[u] = mp_add(t3[u], mp_montymul(w, t4[u], p, p0i), p);
-	}
-
-	/*
-	 * Convert back F*adj(f) + G*adj(g) and f*adj(f) + g*adj(g) to
-	 * plain representation, and move f*adj(f) + g*adj(g) to t2.
-	 */
-	mp_mkigm(logn, t4, PRIMES[0].ig, p, p0i);
-	mp_iNTT(logn, t1, t4, p, p0i);
-	mp_iNTT(logn, t3, t4, p, p0i);
-	for (size_t u = 0; u < n; u ++) {
-		/*
-		 * NOTE: no truncature to 31 bits.
-		 */
-		t1[u] = (uint32_t)mp_norm(t1[u], p);
-		t2[u] = (uint32_t)mp_norm(t3[u], p);
-	}
-
-	/*
-	 * Buffer contents:
-	 *   Fp   unreduced F (RNS+NTT) (n)
-	 *   Gp   unreduced G (RNS+NTT) (n)
-	 *   t1   F*adj(f) + G*adj(g) (plain, 32-bit) (n)
-	 *   t2   f*adj(f) + g*adj(g) (plain, 32-bit) (n)
-	 */
-
-	/*
-	 * We need to divide t1 by t2, and round the result. We convert
-	 * them to FFT representation, downscaled by 2^10 (to avoid overflows).
-	 * We first convert f*adj(f) + g*adj(g), which is auto-adjoint;
-	 * thus, its FFT representation only has half-size.
-	 */
-	fxr *rt3 = (fxr *)t3;
-	for (size_t u = 0; u < n; u ++) {
-		uint64_t x = (uint64_t)*(int32_t *)&t2[u] << 22;
-		rt3[u] = fxr_of_scaled32(x);
-	}
-	vect_FFT(logn, rt3);
-	fxr *rt2 = (fxr *)t2;
-	memmove(rt2, rt3, hn * sizeof *rt3);
-	rt3 = rt2 + hn;
-	/* obsolete
-	kg_stats_set_max_size(logn, 0, 6 * n);
-	*/
-
-	/*
-	 * Buffer contents:
-	 *   Fp    unreduced F (RNS+NTT) (n)
-	 *   Gp    unreduced G (RNS+NTT) (n)
-	 *   t1    F*adj(f) + G*adj(g) (plain, 32-bit) (n)
-	 *   rt2   f*adj(f) + g*adj(g) (FFT, auto-ajdoint) (hn fxr values = n)
-	 *   rt3   free (n fxr values = 2*n)
-	 */
-
-	/*
-	 * Convert F*adj(f) + G*adj(g) to FFT (scaled by 2^10) (into rt3).
-	 */
-	for (size_t u = 0; u < n; u ++) {
-		uint64_t x = (uint64_t)*(int32_t *)&t1[u] << 22;
-		rt3[u] = fxr_of_scaled32(x);
-	}
-	vect_FFT(logn, rt3);
-
-	/*
-	 * Divide F*adj(f) + G*adj(g) by f*adj(f) + g*adj(g) and round
-	 * the result into t1, with conversion to RNS.
-	 */
-	vect_div_autoadj_fft(logn, rt3, rt2);
-	vect_iFFT(logn, rt3);
-	for (size_t u = 0; u < n; u ++) {
-		t1[u] = mp_set(fxr_round(rt3[u]), p);
-	}
-
-	/*
-	 * Buffer contents:
-	 *   Fp    unreduced F (RNS+NTT) (n)
-	 *   Gp    unreduced G (RNS+NTT) (n)
-	 *   t1    k (RNS) (n)
-	 *   t2    free (n)
-	 *   t3    free (n)
-	 *   t4    free (n)
-	 */
-
-	/*
-	 * Convert k to RNS+NTT+Montgomery.
-	 */
-	mp_mkgm(logn, t4, PRIMES[0].g, p, p0i);
-	mp_NTT(logn, t1, t4, p, p0i);
-	for (size_t u = 0; u < n; u ++) {
-		t1[u] = mp_montymul(t1[u], R2, p, p0i);
-	}
-
-	/*
-	 * Subtract k*f from F and k*g from G.
-	 * We also compute f*G - g*F (in RNS+NTT) to check that the solution
-	 * is correct.
-	 */
-	for (size_t u = 0; u < n; u ++) {
-		t2[u] = mp_set(f[u], p);
-		t3[u] = mp_set(g[u], p);
-	}
-	mp_NTT(logn, t2, t4, p, p0i);
-	mp_NTT(logn, t3, t4, p, p0i);
-	uint32_t rv = mp_montymul(prof->q, 1, p, p0i);
-	for (size_t u = 0; u < n; u ++) {
-		Fp[u] = mp_sub(Fp[u], mp_montymul(t1[u], t2[u], p, p0i), p);
-		Gp[u] = mp_sub(Gp[u], mp_montymul(t1[u], t3[u], p, p0i), p);
-		uint32_t x = mp_sub(
-			mp_montymul(t2[u], Gp[u], p, p0i),
-			mp_montymul(t3[u], Fp[u], p, p0i), p);
-		if (x != rv) {
+		if (t3[u] == 0) {
 			return SOLVE_ERR_REDUCE;
 		}
 	}
 
 	/*
-	 * Convert back F and G into normal representation.
+	 * Layout:
+	 *   t1   F (unreduced, RNS+NTT)
+	 *   t2   g (RNS+NTT)
+	 *   t3   f (RNS+NTT)
+	 *   t4   free
+	 *   t5   free
 	 */
-	mp_mkigm(logn, t4, PRIMES[0].ig, p, p0i);
-	mp_iNTT(logn, Fp, t4, p, p0i);
-	mp_iNTT(logn, Gp, t4, p, p0i);
-	poly_mp_norm(logn, Fp, p);
-	poly_mp_norm(logn, Gp, p);
 
-	return SOLVE_OK;
-}
+	/*
+	 * We want to perform the reduction. Since this is the last one,
+	 * we want to be precise, i.e. to use the full expression for k:
+	 *
+	 *   k = round((F*adj(f) + G*adj(g))/(f*adj(f) + g*adj(g)))
+	 *
+	 * We do not have G but we know that G = (q + g*F)/f, which we
+	 * can compute modulo p (the division by f is exact over the
+	 * integers, hence computing it modulo p yields the correct result,
+	 * as long as the coefficients of G are in [-p/2,+p/2], which is
+	 * heuristically the case). We accumulate the numerator and
+	 * denominator into t2 and t3, respectively.
+	 */
+	uint32_t q = prof->q;
+#if NTRUGEN_AVX2
+	if (hn >= 8) {
+		__m256i yp = _mm256_set1_epi32(p);
+		__m256i yp0i = _mm256_set1_epi32(p0i);
+		__m256i yR2 = _mm256_set1_epi32(R2);
+		__m256i yq = _mm256_set1_epi32(q);
+		for (size_t u = 0; u < hn; u += 8) {
+			/* Load values by groups of 8. */
+			__m256i yf0 = _mm256_loadu_si256(
+				(__m256i *)(t3 + u));
+			__m256i yf1 = _mm256_loadu_si256(
+				(__m256i *)(t3 + (n - 8 - u)));
+			__m256i yg0 = _mm256_loadu_si256(
+				(__m256i *)(t2 + u));
+			__m256i yg1 = _mm256_loadu_si256(
+				(__m256i *)(t2 + (n - 8 - u)));
+			__m256i yF0 = _mm256_loadu_si256(
+				(__m256i *)(t1 + u));
+			__m256i yF1 = _mm256_loadu_si256(
+				(__m256i *)(t1 + (n - 8 - u)));
+			__m256i ymg0 = mp_montymul_x8(yg0, yR2, yp, yp0i);
+			__m256i ymg1 = mp_montymul_x8(yg1, yR2, yp, yp0i);
 
-#if 0
-/* unused */
-/*
- * Verify that the given f, g, F and G fulfill the NTRU equation.
- * Returned value is 1 on success, 0 on error.
- *
- * RAM USAGE: 4*n words
- */
-static int
-verify_NTRU(const ntru_profile *restrict prof, unsigned logn,
-	const int8_t *restrict f, const int8_t *restrict g,
-	const int8_t *restrict F, const int8_t *restrict G,
-	uint32_t *tmp)
-{
-	size_t n = (size_t)1 << logn;
-	uint32_t *t1 = tmp;
-	uint32_t *t2 = t1 + n;
-	uint32_t *t3 = t2 + n;
-	uint32_t *t4 = t3 + n;
-	uint32_t p = PRIMES[0].p;
-	uint32_t p0i = PRIMES[0].p0i;
-	mp_mkgm(logn, t4, PRIMES[0].g, p, p0i);
-	for (size_t u = 0; u < n; u ++) {
-		t1[u] = mp_set(f[u], p);
-		t2[u] = mp_set(G[u], p);
-	}
-	mp_NTT(logn, t1, t4, p, p0i);
-	mp_NTT(logn, t2, t4, p, p0i);
-	for (size_t u = 0; u < n; u ++) {
-		t3[u] = mp_montymul(t1[u], t2[u], p, p0i);
-	}
-	for (size_t u = 0; u < n; u ++) {
-		t1[u] = mp_set(g[u], p);
-		t2[u] = mp_set(F[u], p);
-	}
-	mp_NTT(logn, t1, t4, p, p0i);
-	mp_NTT(logn, t2, t4, p, p0i);
-	uint32_t rv = mp_montymul(prof->q, 1, p, p0i);
-	for (size_t u = 0; u < n; u ++) {
-		uint32_t x = mp_montymul(t1[u], t2[u], p, p0i);
-		if (mp_sub(t3[u], x, p) != rv) {
-			return 0;
+			/* Compute G. */
+			__m256i yG0 = mp_div_x8(
+				mp_add_x8(mp_montymul_x8(ymg0, yF0, yp, yp0i),
+					yq, yp),
+				yf0, yp);
+			__m256i yG1 = mp_div_x8(
+				mp_add_x8(mp_montymul_x8(ymg1, yF1, yp, yp0i),
+					yq, yp),
+				yf1, yp);
+
+			/* We need adj(f) and adj(g), which entails reversing
+			   the order of the values. */
+			__m256i yfa1 = _mm256_permute4x64_epi64(yf0, 0x4E);
+			yfa1 = _mm256_shuffle_epi32(yfa1, 0x1B);
+			__m256i yfa0 = _mm256_permute4x64_epi64(yf1, 0x4E);
+			yfa0 = _mm256_shuffle_epi32(yfa0, 0x1B);
+			__m256i ymga1 = _mm256_permute4x64_epi64(ymg0, 0x4E);
+			ymga1 = _mm256_shuffle_epi32(ymga1, 0x1B);
+			__m256i ymga0 = _mm256_permute4x64_epi64(ymg1, 0x4E);
+			ymga0 = _mm256_shuffle_epi32(ymga0, 0x1B);
+
+			__m256i ymfa0 = mp_montymul_x8(yfa0, yR2, yp, yp0i);
+			__m256i ymfa1 = mp_montymul_x8(yfa1, yR2, yp, yp0i);
+
+			/* kn <- F*adj(f) + G*adj(g) */
+			__m256i ykn0 = mp_add_x8(
+				mp_montymul_x8(ymfa0, yF0, yp, yp0i),
+				mp_montymul_x8(ymga0, yG0, yp, yp0i), yp);
+			__m256i ykn1 = mp_add_x8(
+				mp_montymul_x8(ymfa1, yF1, yp, yp0i),
+				mp_montymul_x8(ymga1, yG1, yp, yp0i), yp);
+
+			/* kd <- f*adj(f) + g*adj(g)
+			   kd is auto-adjoint, hence we can compute the
+			   right half as a swap of the left half. */
+			__m256i ykd0 = mp_add_x8(
+				mp_montymul_x8(ymfa0, yf0, yp, yp0i),
+				mp_montymul_x8(ymga0, yg0, yp, yp0i), yp);
+			__m256i ykd1 = _mm256_permute4x64_epi64(ykd0, 0x4E);
+			ykd1 = _mm256_shuffle_epi32(ykd1, 0x1B);
+
+			_mm256_storeu_si256((__m256i *)(t2 + u), ykn0);
+			_mm256_storeu_si256((__m256i *)(t2 + n - 8 - u), ykn1);
+			_mm256_storeu_si256((__m256i *)(t3 + u), ykd0);
+			_mm256_storeu_si256((__m256i *)(t3 + n - 8 - u), ykd1);
+		}
+	} else {
+		for (size_t u = 0; u < hn; u ++) {
+			uint32_t tf0 = t3[u];
+			uint32_t tf1 = t3[n - 1 - u];
+			uint32_t tg0 = t2[u];
+			uint32_t tg1 = t2[n - 1 - u];
+			uint32_t tF0 = t1[u];
+			uint32_t tF1 = t1[n - 1 - u];
+			uint32_t mf0 = mp_montymul(tf0, R2, p, p0i);
+			uint32_t mf1 = mp_montymul(tf1, R2, p, p0i);
+			uint32_t mg0 = mp_montymul(tg0, R2, p, p0i);
+			uint32_t mg1 = mp_montymul(tg1, R2, p, p0i);
+			uint32_t tG0 = mp_div(
+				mp_add(q, mp_montymul(mg0, tF0, p, p0i), p),
+				tf0, p);
+			uint32_t tG1 = mp_div(
+				mp_add(q, mp_montymul(mg1, tF1, p, p0i), p),
+				tf1, p);
+			uint32_t kn0 = mp_add(
+				mp_montymul(mf1, tF0, p, p0i),
+				mp_montymul(mg1, tG0, p, p0i), p);
+			uint32_t kn1 = mp_add(
+				mp_montymul(mf0, tF1, p, p0i),
+				mp_montymul(mg0, tG1, p, p0i), p);
+			uint32_t kd = mp_add(
+				mp_montymul(mf0, tf1, p, p0i),
+				mp_montymul(mg0, tg1, p, p0i), p);
+			t2[u] = kn0;
+			t2[n - 1 - u] = kn1;
+			t3[u] = kd;
+			t3[n - 1 - u] = kd;
 		}
 	}
-	return 1;
+#else // NTRUGEN_AVX2
+	for (size_t u = 0; u < hn; u ++) {
+		uint32_t tf0 = t3[u];
+		uint32_t tf1 = t3[n - 1 - u];
+		uint32_t tg0 = t2[u];
+		uint32_t tg1 = t2[n - 1 - u];
+		uint32_t tF0 = t1[u];
+		uint32_t tF1 = t1[n - 1 - u];
+		uint32_t mf0 = mp_montymul(tf0, R2, p, p0i);
+		uint32_t mf1 = mp_montymul(tf1, R2, p, p0i);
+		uint32_t mg0 = mp_montymul(tg0, R2, p, p0i);
+		uint32_t mg1 = mp_montymul(tg1, R2, p, p0i);
+		uint32_t tG0 = mp_div(
+			mp_add(q, mp_montymul(mg0, tF0, p, p0i), p), tf0, p);
+		uint32_t tG1 = mp_div(
+			mp_add(q, mp_montymul(mg1, tF1, p, p0i), p), tf1, p);
+		uint32_t kn0 = mp_add(
+			mp_montymul(mf1, tF0, p, p0i),
+			mp_montymul(mg1, tG0, p, p0i), p);
+		uint32_t kn1 = mp_add(
+			mp_montymul(mf0, tF1, p, p0i),
+			mp_montymul(mg0, tG1, p, p0i), p);
+		uint32_t kd = mp_add(
+			mp_montymul(mf0, tf1, p, p0i),
+			mp_montymul(mg0, tg1, p, p0i), p);
+		t2[u] = kn0;
+		t2[n - 1 - u] = kn1;
+		t3[u] = kd;
+		t3[n - 1 - u] = kd;
+	}
+#endif // NTRUGEN_AVX2
+
+	/*
+	 * Current layout:
+	 *   t1   unreduced F (RNS+NTT)
+	 *   t2   F*adj(f) + G*adj(g) (RNS+NTT)
+	 *   t3   f*adj(f) + g*adj(g) (RNS+NTT)
+	 *   t4   free
+	 *   t5   free
+	 */
+
+	/*
+	 * Convert back numerator and denominator to plain integers.
+	 */
+	mp_mkigm(logn, t4, PRIMES[0].ig, p, p0i);
+	mp_iNTT(logn, t2, t4, p, p0i);
+	mp_iNTT(logn, t3, t4, p, p0i);
+#if NTRUGEN_AVX2
+	if (n >= 8) {
+		__m256i yp = _mm256_set1_epi32(p);
+		__m256i yhp = _mm256_set1_epi32((p + 1) >> 1);
+		for (size_t u = 0; u < n; u += 8) {
+			__m256i yn = _mm256_loadu_si256((__m256i *)(t2 + u));
+			__m256i yd = _mm256_loadu_si256((__m256i *)(t3 + u));
+			yn = mp_norm_x8(yn, yp, yhp);
+			yd = mp_norm_x8(yd, yp, yhp);
+			_mm256_storeu_si256((__m256i *)(t2 + u), yn);
+			_mm256_storeu_si256((__m256i *)(t3 + u), yd);
+		}
+	} else {
+		for (size_t u = 0; u < n; u ++) {
+			t2[u] = (uint32_t)mp_norm(t2[u], p);
+			t3[u] = (uint32_t)mp_norm(t3[u], p);
+		}
+	}
+#else // NTRUGEN_AVX2
+	for (size_t u = 0; u < n; u ++) {
+		/*
+		 * NOTE: no truncature to 31 bits.
+		 */
+		t2[u] = (uint32_t)mp_norm(t2[u], p);
+		t3[u] = (uint32_t)mp_norm(t3[u], p);
+	}
+#endif // NTRUGEN_AVX2
+
+#define DOWNSCALE   10
+	/*
+	 * We need to divide t2 by t3, and round the result. We convert
+	 * them to FFT representation, downscaled by 2^10 (to avoid overflows).
+	 * We first convert f*adj(f) + g*adj(g), which is auto-adjoint;
+	 * thus, its FFT representation only has half-size.
+	 */
+	fxr *rt4 = (fxr *)t4;
+	for (size_t u = 0; u < n; u ++) {
+		uint64_t x = (uint64_t)*(int32_t *)&t3[u] << (32 - DOWNSCALE);
+		rt4[u] = fxr_of_scaled32(x);
+	}
+	vect_FFT(logn, rt4);
+	memcpy(rt4 + hn, rt4, hn * sizeof *rt4);
+	fxr *rt5 = rt4 + hn;
+	fxr *rt3 = (fxr *)t3;
+	for (size_t u = 0; u < n; u ++) {
+		uint64_t x = (uint64_t)*(int32_t *)&t2[u] << (32 - DOWNSCALE);
+		rt3[u] = fxr_of_scaled32(x);
+	}
+	vect_FFT(logn, rt3);
+#undef DOWNSCALE
+
+	/*
+	 * Current layout:
+	 *   t1   unreduced F (RNS+NTT)
+	 *   t2   free
+	 *   t3   F*adj(f) + G*adj(g) (FFT) (first half)   <- alias: rt3
+	 *   t4   F*adj(f) + G*adj(g) (FFT) (second half)
+	 *   t5   f*adj(f) + g*adj(g) (FFT) (half-size)    <- alias: rt5
+	 */
+
+	/*
+	 * Divide F*adj(f) + G*adj(g) by f*adj(f) + g*adj(g) and round
+	 * the result into t2, with conversion to RNS.
+	 */
+	vect_div_autoadj_fft(logn, rt3, rt5);
+	vect_iFFT(logn, rt3);
+	for (size_t u = 0; u < n; u ++) {
+		t2[u] = mp_set(fxr_round(rt3[u]), p);
+	}
+
+	/*
+	 * Current layout:
+	 *   t1   unreduced F (RNS+NTT)
+	 *   t2   k (RNS)
+	 *   t3   free
+	 *   t4   free
+	 *   t5   free
+	 */
+
+	/*
+	 * Get back f and g, and convert all polynomials to RNS+NTT.
+	 */
+	gm = t5;
+	mp_mkgm(logn, gm, PRIMES[0].g, p, p0i);
+	poly_mp_set_small(logn, t3, f, p);
+	poly_mp_set_small(logn, t4, g, p);
+	mp_NTT(logn, t2, gm, p, p0i);
+	mp_NTT(logn, t3, gm, p, p0i);
+	mp_NTT(logn, t4, gm, p, p0i);
+
+	/*
+	 * Current layout:
+	 *   t1   unreduced F (RNS+NTT)
+	 *   t2   k (RNS+NTT)
+	 *   t3   f (RNS+NTT)
+	 *   t4   g (RNS+NTT)
+	 *   t5   free
+	 */
+
+	/*
+	 * Reduce F by subtracting k*f, and recompute the corresponding G
+	 * with:
+	 *   G = (q + g*F)/f
+	 * (We computed the unreduced G, but did not keep it, in order to
+	 * save RAM; if we had kept it in an extra buffer, then we could
+	 * reduce it by subtracting k*g, which would be faster than the
+	 * division.)
+	 */
+#if NTRUGEN_AVX2
+	if (n >= 8) {
+		__m256i yp = _mm256_set1_epi32(p);
+		__m256i yp0i = _mm256_set1_epi32(p0i);
+		__m256i yR2 = _mm256_set1_epi32(R2);
+		__m256i yq = _mm256_set1_epi32(q);
+		for (size_t u = 0; u < n; u += 8) {
+			__m256i yF = _mm256_loadu_si256((__m256i *)(t1 + u));
+			__m256i yk = _mm256_loadu_si256((__m256i *)(t2 + u));
+			__m256i yf = _mm256_loadu_si256((__m256i *)(t3 + u));
+			__m256i yg = _mm256_loadu_si256((__m256i *)(t4 + u));
+			__m256i ymf = mp_montymul_x8(yf, yR2, yp, yp0i);
+			__m256i ymg = mp_montymul_x8(yg, yR2, yp, yp0i);
+			yF = mp_sub_x8(yF,
+				mp_montymul_x8(ymf, yk, yp, yp0i), yp);
+			__m256i yG = mp_div_x8(
+				mp_add_x8(yq,
+					mp_montymul_x8(ymg, yF, yp, yp0i), yp),
+				yf, yp);
+			_mm256_storeu_si256((__m256i *)(t1 + u), yF);
+			_mm256_storeu_si256((__m256i *)(t2 + u), yG);
+		}
+	} else {
+		for (size_t u = 0; u < n; u ++) {
+			uint32_t tF = t1[u];
+			uint32_t tk = t2[u];
+			uint32_t tf = t3[u];
+			uint32_t tg = t4[u];
+			uint32_t mf = mp_montymul(tf, R2, p, p0i);
+			uint32_t mg = mp_montymul(tg, R2, p, p0i);
+			tF = mp_sub(tF, mp_montymul(mf, tk, p, p0i), p);
+			uint32_t tG = mp_div(
+				mp_add(q, mp_montymul(mg, tF, p, p0i), p),
+				tf, p);
+			t1[u] = tF;
+			t2[u] = tG;
+		}
+	}
+#else // NTRUGEN_AVX2
+	for (size_t u = 0; u < n; u ++) {
+		uint32_t tF = t1[u];
+		uint32_t tk = t2[u];
+		uint32_t tf = t3[u];
+		uint32_t tg = t4[u];
+		uint32_t mf = mp_montymul(tf, R2, p, p0i);
+		uint32_t mg = mp_montymul(tg, R2, p, p0i);
+		tF = mp_sub(tF, mp_montymul(mf, tk, p, p0i), p);
+		uint32_t tG = mp_div(
+			mp_add(q, mp_montymul(mg, tF, p, p0i), p), tf, p);
+		t1[u] = tF;
+		t2[u] = tG;
+	}
+#endif // NTRUGEN_AVX2
+
+	/*
+	 * Convert back F and G into normal representation.
+	 */
+	mp_mkigm(logn, t3, PRIMES[0].ig, p, p0i);
+	mp_iNTT(logn, t1, t3, p, p0i);
+	mp_iNTT(logn, t2, t3, p, p0i);
+	poly_mp_norm(logn, t1, p);
+	poly_mp_norm(logn, t2, p);
+
+	/*
+	 * We're done! By construction, f*G - g*F = q modulo p; if both
+	 * F and G are in the correct range ([-127,+127]) then this
+	 * equation will also hold over plain integers:
+	 *   N_inf(f*G - g*F) <= (127^2)*n*2 < 2^25 < p/2
+	 * Verifying that F and G are in range is done by the caller.
+	 */
+	return SOLVE_OK;
 }
-#endif
 
 /* see ng_inner.h */
 int


### PR DESCRIPTION
Hawk keygen was initially imported from https://github.com/pornin/ntrugen

A new version has been pushed recently, with an improved method for solving the NTRU equation; for Hawk, it's 11 to 26% faster (depending on degree) and uses less RAM for temporary storage (`22*n` bytes instead of `26*n`). This PR imports the new code. As a side effect, generated keys for a given seed change (the new method does not fail/succeed on exactly the same (f,g) pairs as the older one); however, everything is still in-spec and interoperable.
